### PR TITLE
Add proper sync notation

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
 
 var extend = require('xtend/mutable');
 var util = require('audio-buffer-utils');
+var pcm = require('pcm-util');
 
 
 module.exports = Generator;
@@ -25,15 +26,13 @@ function Generator (fn, opts) {
 
 	//sort out arguments
 	opts = extend({
-		sampleRate: 44100,
-
 		//total duration of a stream
 		duration: Infinity,
 
 		//time repeat period, in seconds, or 1/frequency
 		period: Infinity,
 
-		//detected from period
+		//inferred from period
 		//frequency: 0,
 
 		/**
@@ -43,7 +42,7 @@ function Generator (fn, opts) {
 		 * @param {number} time current time
 		 */
 		generate: Math.random
-	}, opts);
+	}, pcm.defaults, opts);
 
 	//align frequency/period
 	if (opts.frequency != null) {
@@ -54,8 +53,15 @@ function Generator (fn, opts) {
 
 	let time = 0, count = 0;
 
-	//return sync map
-	return function (buffer) {
+	//wrapper for convenience, there is nothing to end
+	generate.end = function () {};
+
+	return generate;
+
+	//return sync source/map
+	function generate (buffer) {
+		if (!buffer) buffer = util.create(opts.channels, opts.samplesPerFrame, opts.sampleRate);
+
 		//get audio buffer channels data in array
 		var data = util.data(buffer);
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "codemirror": "^5.7.0",
     "fnbody": "latest",
     "inherits": "^2.0.1",
+    "pcm-util": "^2.0.3",
     "stacktrace-parser": "^0.1.3",
     "xtend": "^4.0.0"
   }


### PR DESCRIPTION
I guess with that you could remove buffer creation from _pull.js_. Also there is `end` method convention - should we make that method obligatory for all streams?
