### PR TITLE
Fix error in README.md (Direct)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ Generate audio stream with a function.
 #### Direct
 
 ```js
-const generator = require('audio-generator');
+const generator = require('audio-generator/index');
 const speaker = require('audio-speaker');
 
 // panned sine generator

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ Generate audio stream with a function.
 #### Direct
 
 ```js
-const generator = require('audio-generator/index');
+const generator = require('audio-generator/direct');
 const speaker = require('audio-speaker');
 
 // panned sine generator

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Generate audio stream with a function.
 
 ```js
 const generator = require('audio-generator/direct');
-const speaker = require('audio-speaker');
+const speaker = require('audio-speaker/direct');
 
 // panned sine generator
 let generate = generator(time => [


### PR DESCRIPTION
Following instructions for 'Direct' use in Readme.md creates a `TypeError: generate is not a function`:

To duplicate follow these steps:

```
$ node -v && node
v6.10.0
> const generator = require('audio-generator');
undefined
> const generate = generator(time => Math.sin(time * Math.PI * 2 * 440));
undefined
> typeof generate
'object'
> generate()
TypeError: generate is not a function
    at repl:1:1
    at sigintHandlersWrap (vm.js:22:35)
    at sigintHandlersWrap (vm.js:96:12)
    at ContextifyScript.Script.runInThisContext (vm.js:21:12)
    at REPLServer.defaultEval (repl.js:340:29)
    at bound (domain.js:280:14)
    at REPLServer.runBound [as eval] (domain.js:293:12)
    at REPLServer.<anonymous> (repl.js:538:10)
    at emitOne (events.js:101:20)
    at REPLServer.emit (events.js:188:7)
```

This is happening because `package.json` is pointing `main` to `stream.js`. 

Instead of repointing the `package.json` (which may have undesired effects elsewhere) the workaround here is to point directly to the direct `direct.js` (Generator) function.